### PR TITLE
Add AI/ML Workshop at MIT WPU Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Google Developer Group Women in Tech (GDG WOW) Pune is a community-driven initia
 - **Networking Events**: Opportunities to connect with like-minded professionals
 - **Study Jams**: Group learning sessions on specific technologies
 
+### Recent Events
+- [AI/ML Workshop at MIT WPU](./workshops/aiml-mit-wpu-2025.md) - April 20, 2025
+
 ## Get Involved
 
 - Join our community on [GDG Community Platform](https://gdg.community.dev/)

--- a/workshops/aiml-mit-wpu-2025.md
+++ b/workshops/aiml-mit-wpu-2025.md
@@ -1,0 +1,66 @@
+# AI/ML Workshop at MIT WPU - April 20, 2025
+
+## Event Overview
+
+On April 20, 2025, GDGoC Pune hosted an exciting AI/ML workshop at MIT World Peace University. The event brought together students, developers, and AI enthusiasts for a day of learning and hands-on experience with cutting-edge technologies.
+
+## Workshop Content
+
+The workshop focused on practical applications of AI/ML technologies, providing participants with both theoretical knowledge and hands-on experience:
+
+### Morning Session
+- Introduction to AI/ML fundamentals
+- Overview of Google Cloud's AI/ML offerings
+- Understanding model training and deployment
+- Best practices for AI implementation
+
+### Afternoon Session
+- Hands-on lab: Building an MCP (Master Control Program) server
+- Implementing machine learning models
+- Real-time AI processing techniques
+- Deployment and testing
+
+## MCP Server Project
+
+A highlight of the workshop was the hands-on creation of an MCP server that demonstrated:
+
+1. Setting up a proper environment for AI/ML workloads
+2. Configuring necessary dependencies and libraries
+3. Implementing basic AI functionalities for real-time processing
+4. Deploying the server for practical use cases
+
+Participants successfully built functioning MCP servers that could:
+- Process incoming data streams
+- Apply trained ML models to the data
+- Provide intelligent responses based on the analysis
+- Scale according to processing needs
+
+## Workshop Impact
+
+The workshop was attended by over 60 participants who gained valuable skills and insights:
+
+- **For Students**: Practical experience with AI/ML technologies that complement academic learning
+- **For Developers**: Exposure to production-ready AI implementation techniques
+- **For Enthusiasts**: Introduction to AI concepts with tangible results
+
+## Resources
+
+- [Workshop Slides](https://gdgwowpune.org/resources/aiml-workshop-slides)
+- [Code Samples](https://github.com/gdgwowpune/aiml-workshop-code)
+- [Setup Instructions](https://gdgwowpune.org/resources/mcp-setup)
+
+## Acknowledgments
+
+Special thanks to:
+- MIT World Peace University for hosting the event
+- The GDGoC Pune organizing team
+- Our guest speakers and mentors
+- All participants for their enthusiasm and engagement
+
+## What's Next
+
+This workshop is part of our ongoing series on AI/ML technologies. Stay tuned for future events where we'll explore more advanced topics and build upon what we learned today.
+
+---
+
+*For more information about upcoming events, join our community on the [GDG Community Platform](https://gdg.community.dev/).*


### PR DESCRIPTION
## Description

This PR adds documentation for the AI/ML workshop held at MIT WPU on April 20, 2025. It includes:

1. Update to README.md with a link to the workshop details
2. New file with comprehensive workshop details including:
   - Workshop content overview
   - MCP server project details
   - Resources and acknowledgments

## Changes Made
- Added a "Recent Events" section to README.md with a link to the workshop
- Created `workshops/aiml-mit-wpu-2025.md` with detailed information about the workshop

## Screenshot
N/A

## Additional Notes
The workshop was a great success with over 60 participants who learned about AI/ML concepts and built their own MCP servers.